### PR TITLE
Add list and focus commands for branch management

### DIFF
--- a/src/commands/focus.js
+++ b/src/commands/focus.js
@@ -1,0 +1,188 @@
+import chalk from 'chalk';
+import { getBranchesWithMetadata } from '../services/gitService.js';
+import { deleteBranch, deleteRemoteBranch } from '../services/gitService.js';
+import { isProtectedBranch } from '../services/protectionService.js';
+import { confirmBranchDeletion } from '../utils/prompts.js';
+
+export const focusCommand = {
+  command: 'focus <indices...>',
+  describe: 'Perform operations on branches by their list index.',
+  builder: yargs =>
+    yargs
+      .positional('indices', {
+        type: 'string',
+        describe: '0-based indices from kwgit list',
+        array: true,
+      })
+      .option('remote', {
+        alias: 'r',
+        type: 'boolean',
+        describe: 'Include remote branches (must match list filters)',
+        default: false,
+      })
+      .option('remote-only', {
+        type: 'boolean',
+        describe: 'Only remote branches (must match list filters)',
+        default: false,
+      })
+      .option('all-branches', {
+        alias: 'a',
+        type: 'boolean',
+        describe: 'Local + remote branches (must match list filters)',
+        default: false,
+      })
+      .option('json', {
+        type: 'boolean',
+        describe: 'Output structured JSON',
+        default: false,
+      })
+      .option('view', {
+        type: 'boolean',
+        describe: 'Only view selected branches (do not delete)',
+        default: false,
+      })
+      .option('force', {
+        alias: 'f',
+        type: 'boolean',
+        describe: 'Force delete',
+        default: false,
+      })
+      .option('yes', {
+        alias: 'y',
+        type: 'boolean',
+        describe: 'Delete all selected branches without individual prompts',
+        default: false,
+      }),
+  handler: async ({ indices, remote, remoteOnly, allBranches, json, view, force, yes }) => {
+    if (!indices || indices.length === 0) {
+      console.error(chalk.red('Error: At least one index is required.'));
+      process.exit(1);
+    }
+
+    const includeRemote = remote || allBranches;
+    const onlyRemote = remoteOnly;
+
+    if (onlyRemote && !includeRemote) {
+      console.error(chalk.red('Error: --remote-only requires remote branches to be included.'));
+      process.exit(1);
+    }
+
+    const branches = await getBranchesWithMetadata({
+      includeRemote: includeRemote || onlyRemote,
+      remoteOnly: onlyRemote,
+    });
+
+    if (branches.length === 0) {
+      console.log(chalk.yellow('No branches found.'));
+      return;
+    }
+
+    const parsedIndices = indices.map(idx => {
+      const num = parseInt(idx, 10);
+      if (isNaN(num) || num < 0) {
+        throw new Error(`Invalid index: ${idx}`);
+      }
+      return num;
+    });
+
+    const invalidIndices = parsedIndices.filter(idx => idx >= branches.length);
+    if (invalidIndices.length > 0) {
+      console.error(chalk.red(`Error: Invalid indices: ${invalidIndices.join(', ')}. Maximum index is ${branches.length - 1}.`));
+      process.exit(1);
+    }
+
+    const selectedBranches = parsedIndices.map(idx => branches[idx]);
+
+    const protectedBranches = selectedBranches.filter(b => b.isProtected);
+    
+    if (protectedBranches.length > 0) {
+      console.error(chalk.red(`Error: Cannot focus on protected branches: ${protectedBranches.map(b => b.name).join(', ')}`));
+      console.error(chalk.yellow('Protected branches cannot be deleted. Remove them from your selection.'));
+      process.exit(1);
+    }
+
+    if (json) {
+      console.log(JSON.stringify(selectedBranches, null, 2));
+      return;
+    }
+
+    if (view) {
+      console.log(chalk.bold(`\nSelected branches:`));
+      selectedBranches.forEach(branch => {
+        const remoteLabel = branch.isRemote ? chalk.gray(' (remote)') : '';
+        const currentLabel = branch.isCurrent ? chalk.cyan(' (current)') : '';
+        const protectedLabel = branch.isProtected ? chalk.gray(' (protected)') : '';
+        console.log(`  • ${chalk.cyan(branch.name)}${remoteLabel}${currentLabel}${protectedLabel}`);
+      });
+      return;
+    }
+
+    const deleteAll = yes;
+
+    const currentBranches = selectedBranches.filter(b => b.isCurrent);
+    if (currentBranches.length > 0) {
+      console.error(chalk.red(`Error: Cannot delete current branch: ${currentBranches.map(b => b.name).join(', ')}`));
+      console.error(chalk.yellow('Switch to a different branch before deleting.'));
+      process.exit(1);
+    }
+
+    const deletableBranches = selectedBranches.filter(b => !b.isCurrent);
+
+    if (deletableBranches.length === 0) {
+      console.log(chalk.yellow('No deletable branches selected.'));
+      return;
+    }
+
+    console.log(chalk.bold(`\nReviewing ${deletableBranches.length} branch${deletableBranches.length === 1 ? '' : 'es'} for deletion:\n`));
+
+    const deletedBranches = [];
+    const skippedBranches = [];
+    const failedBranches = [];
+
+    for (const branch of deletableBranches) {
+      let shouldDelete = deleteAll;
+
+      if (!deleteAll) {
+        const branchLabel = branch.isRemote ? `${branch.name} (remote)` : branch.name;
+        shouldDelete = await confirmBranchDeletion(branchLabel);
+      }
+
+      if (!shouldDelete) {
+        skippedBranches.push(branch);
+        console.log(chalk.gray(`  Skipped ${branch.name}`));
+        continue;
+      }
+
+      try {
+        if (branch.isRemote) {
+          await deleteRemoteBranch(branch.name);
+          deletedBranches.push(branch);
+          console.log(chalk.green(`  ✓ Deleted remote branch: ${branch.name}`));
+        } else {
+          await deleteBranch(branch.name, force);
+          deletedBranches.push(branch);
+          console.log(chalk.green(`  ✓ Deleted local branch: ${branch.name}`));
+        }
+      } catch (err) {
+        failedBranches.push({ branch, error: err });
+        const remoteLabel = branch.isRemote ? 'remote ' : '';
+        console.error(chalk.red(`  ✗ Failed to delete ${remoteLabel}branch ${branch.name}: ${err.message}`));
+      }
+    }
+
+    console.log();
+
+    if (deletedBranches.length > 0) {
+      console.log(chalk.green(`✓ Successfully deleted ${deletedBranches.length} branch${deletedBranches.length === 1 ? '' : 'es'}.`));
+    }
+
+    if (skippedBranches.length > 0) {
+      console.log(chalk.yellow(`⊘ Skipped ${skippedBranches.length} branch${skippedBranches.length === 1 ? '' : 'es'}.`));
+    }
+
+    if (failedBranches.length > 0) {
+      console.log(chalk.red(`✗ Failed to delete ${failedBranches.length} branch${failedBranches.length === 1 ? '' : 'es'}.`));
+    }
+  },
+};
+

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -1,5 +1,7 @@
 import { cleanCommand } from './clean.js';
 import { staleCommand } from './stale.js';
+import { listCommand } from './list.js';
+import { focusCommand } from './focus.js';
 
 /**
  * This function registers all available commands with yargs.
@@ -8,5 +10,7 @@ import { staleCommand } from './stale.js';
 export function registerCommands(yargsInstance) {
   return yargsInstance
     .command(cleanCommand)
-    .command(staleCommand);
+    .command(staleCommand)
+    .command(listCommand)
+    .command(focusCommand);
 }

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -1,0 +1,59 @@
+import chalk from 'chalk';
+import { getBranchesWithMetadata } from '../services/gitService.js';
+import { formatBranchListTable, formatBranchListJson } from '../utils/formatters.js';
+
+export const listCommand = {
+  command: 'list',
+  describe: 'List all branches with metadata (creation date, last commit, age).',
+  builder: yargs =>
+    yargs
+      .option('remote', {
+        alias: 'r',
+        type: 'boolean',
+        describe: 'Include remote branches',
+        default: false,
+      })
+      .option('remote-only', {
+        type: 'boolean',
+        describe: 'Only remote branches',
+        default: false,
+      })
+      .option('all', {
+        alias: 'a',
+        type: 'boolean',
+        describe: 'Local + remote branches',
+        default: false,
+      })
+      .option('json', {
+        type: 'boolean',
+        describe: 'Output structured JSON',
+        default: false,
+      }),
+  handler: async ({ remote, remoteOnly, all, json }) => {
+    const includeRemote = remote || all;
+    const onlyRemote = remoteOnly;
+
+    if (onlyRemote && !includeRemote) {
+      console.error(chalk.red('Error: --remote-only requires remote branches to be included.'));
+      process.exit(1);
+    }
+
+    const branches = await getBranchesWithMetadata({
+      includeRemote: includeRemote || onlyRemote,
+      remoteOnly: onlyRemote,
+    });
+
+    if (branches.length === 0) {
+      console.log(chalk.yellow('No branches found.'));
+      return;
+    }
+
+    if (json) {
+      console.log(formatBranchListJson(branches));
+    } else {
+      const currentBranch = branches.find(b => b.isCurrent)?.name || null;
+      console.log(formatBranchListTable(branches, currentBranch));
+    }
+  },
+};
+

--- a/src/services/gitService.js
+++ b/src/services/gitService.js
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import simpleGit from 'simple-git';
+import { isProtectedBranch } from './protectionService.js';
 
 /**
  * Initialize a simple-git instance at the current working directory.
@@ -69,4 +70,132 @@ export async function remoteBranchExists(branchName, remote = 'origin') {
   const fullName = `${remote}/${branchName}`;
 
   return result.all.includes(fullName);
+}
+
+/**
+ * Gets the current branch name.
+ */
+export async function getCurrentBranch() {
+  const result = await getGit().branchLocal();
+  return result.current;
+}
+
+/**
+ * Gets the actual branch creation timestamp from reflog
+ * Returns the timestamp of the oldest reflog entry (branch creation)
+ */
+async function getBranchCreationTimestamp(branchName) {
+  try {
+    const git = getGit();
+    const result = await git.raw(['reflog', 'show', '--date=unix', branchName]);
+    const lines = result.trim().split('\n').filter(line => line.trim());
+    if (lines.length > 0) {
+      const lastLine = lines[lines.length - 1];
+      const match = lastLine.match(/@\{(\d+)\}/);
+      if (match && match[1]) {
+        const timestamp = parseInt(match[1], 10);
+        return isNaN(timestamp) ? null : timestamp;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Gets branches with metadata (creation date, last commit date, etc.)
+ * @param {Object} options - Filtering options
+ * @param {boolean} options.includeRemote - Include remote branches
+ * @param {boolean} options.remoteOnly - Only remote branches
+ * @returns {Promise<Array>} Array of branch objects with metadata
+ */
+export async function getBranchesWithMetadata({ includeRemote = false, remoteOnly = false } = {}) {
+  const git = getGit();
+  const currentBranch = await getCurrentBranch();
+  const branches = [];
+
+  if (!remoteOnly) {
+    const localRefs = await git.raw([
+      'for-each-ref',
+      'refs/heads',
+      '--format=%(refname:short)|%(creatordate:unix)|%(committerdate:unix)'
+    ]);
+
+    const localLines = localRefs.trim().split('\n').filter(line => line.trim());
+    
+    for (const line of localLines) {
+      const [name, creatorDate, commitDate] = line.split('|');
+      
+      if (!name) continue;
+
+      const lastCommitTimestamp = parseInt(commitDate, 10);
+      if (isNaN(lastCommitTimestamp)) {
+        continue;
+      }
+
+      let creationTimestamp = parseInt(creatorDate, 10);
+      if (isNaN(creationTimestamp) || creationTimestamp === 0) {
+        creationTimestamp = lastCommitTimestamp;
+      }
+
+      const reflogCreationTimestamp = await getBranchCreationTimestamp(name);
+      if (reflogCreationTimestamp) {
+        if (creationTimestamp === lastCommitTimestamp || reflogCreationTimestamp < creationTimestamp) {
+          creationTimestamp = reflogCreationTimestamp;
+        }
+      }
+
+      branches.push({
+        name,
+        creationDate: creationTimestamp,
+        lastCommitDate: lastCommitTimestamp,
+        isCurrent: name === currentBranch,
+        isRemote: false,
+        isProtected: isProtectedBranch(name)
+      });
+    }
+  }
+
+  if (includeRemote || remoteOnly) {
+    const remoteRefs = await git.raw([
+      'for-each-ref',
+      'refs/remotes',
+      '--format=%(refname:short)|%(creatordate:unix)|%(committerdate:unix)'
+    ]);
+
+    const remoteLines = remoteRefs.trim().split('\n').filter(line => line.trim());
+    
+    for (const line of remoteLines) {
+      const [fullName, creatorDate, commitDate] = line.split('|');
+      
+      if (!fullName) continue;
+
+      const parts = fullName.split('/');
+      if (parts.length < 2) continue;
+
+      const name = parts.slice(1).join('/');
+      let creationTimestamp = parseInt(creatorDate, 10);
+      const lastCommitTimestamp = parseInt(commitDate, 10);
+
+      if (isNaN(creationTimestamp) || creationTimestamp === 0) {
+        creationTimestamp = lastCommitTimestamp;
+      }
+
+      if (isNaN(lastCommitTimestamp)) {
+        continue;
+      }
+
+      branches.push({
+        name,
+        creationDate: creationTimestamp,
+        lastCommitDate: lastCommitTimestamp,
+        isCurrent: false,
+        isRemote: true,
+        isProtected: isProtectedBranch(name)
+      });
+    }
+  }
+
+  return branches.sort((a, b) => a.creationDate - b.creationDate);
 }

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -1,0 +1,157 @@
+import chalk from 'chalk';
+
+/**
+ * Formats age in seconds to human-readable format (d, w, m, y)
+ */
+export function formatAge(seconds) {
+  const days = Math.floor(seconds / 86400);
+  const weeks = Math.floor(days / 7);
+  const months = Math.floor(days / 30);
+  const years = Math.floor(days / 365);
+
+  if (years > 0) {
+    return `${years}y`;
+  }
+  if (months > 0) {
+    return `${months}m`;
+  }
+  if (weeks > 0) {
+    return `${weeks}w`;
+  }
+  return `${days}d`;
+}
+
+/**
+ * Formats timestamp to readable date string
+ */
+export function formatDate(timestamp) {
+  const date = new Date(timestamp * 1000);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  });
+}
+
+/**
+ * Returns chalk color function based on staleness
+ */
+export function getStalenessColor(ageInDays) {
+  if (ageInDays < 7) {
+    return chalk.reset;
+  }
+  if (ageInDays < 30) {
+    return chalk.yellow;
+  }
+  return chalk.red;
+}
+
+/**
+ * Strips ANSI color codes from a string
+ */
+function stripAnsi(str) {
+  return str.replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+/**
+ * Pads a string with ANSI codes, accounting for their length
+ */
+function padWithAnsi(str, width) {
+  const stripped = stripAnsi(str);
+  const padding = Math.max(0, width - stripped.length);
+  return str + ' '.repeat(padding);
+}
+
+/**
+ * Formats branches as a table for terminal output
+ */
+export function formatBranchListTable(branches, currentBranch) {
+  if (branches.length === 0) {
+    return '';
+  }
+
+  const rows = [];
+  const headers = ['Index', 'Branch', 'Created', 'Last Commit', 'Age'];
+  const columnWidths = [5, 35, 15, 15, 8];
+
+  rows.push(headers.map((h, i) => h.padEnd(columnWidths[i])).join('  '));
+  rows.push(headers.map((_, i) => '-'.repeat(columnWidths[i])).join('  '));
+
+  for (let i = 0; i < branches.length; i++) {
+    const branch = branches[i];
+    const now = Math.floor(Date.now() / 1000);
+    
+    const ageInSeconds = now - branch.lastCommitDate;
+    const age = formatAge(ageInSeconds);
+    
+    let stalenessAgeInDays;
+    if (branch.creationDate > branch.lastCommitDate) {
+      stalenessAgeInDays = Math.floor((now - branch.creationDate) / 86400);
+    } else {
+      stalenessAgeInDays = Math.floor(ageInSeconds / 86400);
+    }
+    
+    let branchName = branch.name;
+    if (branch.isRemote) {
+      branchName = `${branchName} ${chalk.gray('(remote)')}`;
+    }
+    if (branch.isCurrent) {
+      branchName = `${chalk.cyan('*')} ${branchName}`;
+    }
+
+    let colorFn;
+    let coloredBranchName;
+    let coloredAge;
+    
+    if (branch.isProtected && branch.isCurrent) {
+      colorFn = chalk.cyan;
+      coloredBranchName = colorFn(`${branchName} ${chalk.gray('(protected)')}`);
+      coloredAge = colorFn(age);
+    } else if (branch.isProtected) {
+      colorFn = chalk.dim;
+      coloredBranchName = colorFn(`${branchName} ${chalk.gray('(protected)')}`);
+      coloredAge = colorFn(age);
+    } else if (branch.isCurrent) {
+      colorFn = chalk.cyan;
+      coloredBranchName = colorFn(branchName);
+      coloredAge = colorFn(age);
+    } else {
+      colorFn = getStalenessColor(stalenessAgeInDays);
+      coloredBranchName = colorFn(branchName);
+      coloredAge = colorFn(age);
+    }
+
+    const index = i.toString().padEnd(columnWidths[0]);
+    const branchCol = padWithAnsi(coloredBranchName, columnWidths[1]);
+    const created = formatDate(branch.creationDate).padEnd(columnWidths[2]);
+    const lastCommit = formatDate(branch.lastCommitDate).padEnd(columnWidths[3]);
+    const ageCol = padWithAnsi(coloredAge, columnWidths[4]);
+
+    rows.push(`${index}  ${branchCol}  ${created}  ${lastCommit}  ${ageCol}`);
+  }
+
+  return rows.join('\n');
+}
+
+/**
+ * Formats branches as JSON array
+ */
+export function formatBranchListJson(branches) {
+  const now = Math.floor(Date.now() / 1000);
+  
+  return JSON.stringify(
+    branches.map(branch => {
+      const ageInSeconds = now - branch.lastCommitDate;
+      return {
+        name: branch.name,
+        creationDate: branch.creationDate,
+        lastCommitDate: branch.lastCommitDate,
+        age: formatAge(ageInSeconds),
+        isProtected: branch.isProtected || false
+      };
+    }),
+    null,
+    2
+  );
+}
+


### PR DESCRIPTION
Implement two new commands that work together to provide an interactive branch management experience:

kwgit list:
- Display all branches with metadata (index, name, creation date, last commit, age)
- Support filtering: --remote, --remote-only, --all
- Color coding based on staleness (< 7 days normal, 7-30 days yellow, > 30 days red)
- Special handling for protected branches (dimmed with "(protected)" label)
- Current branch highlighted in cyan
- JSON output option with --json
- Uses reflog to detect actual branch creation dates (more accurate than creatordate)

kwgit focus:
- Operate on branches by their list index
- Default behavior: prompt for each branch individually (delete or skip)
- --view flag: only view selected branches (no deletion)
- --yes flag: delete all selected branches without prompts
- Excludes protected branches (error if selected)
- Excludes current branch from deletion (error if attempted)
- Supports same filtering options as list command
- Shows summary of deleted, skipped, and failed branches

Technical improvements:
- Added getBranchesWithMetadata() to gitService for branch discovery
- Uses git for-each-ref for efficient branch metadata retrieval
- Falls back to reflog for accurate branch creation timestamps
- Staleness coloring uses branch creation date when more recent than commit date
- New formatters.js utility for table and JSON output formatting
- Proper ANSI color code handling in table formatting